### PR TITLE
ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,79 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm run check
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build
+        env:
+          # Set the base path for GitHub Pages (served at /Pawnly/)
+          KIT_BASE_PATH: /Pawnly
+          # Supabase credentials -- set these as GitHub repository secrets:
+          #   PUBLIC_SUPABASE_URL      -> your Supabase project URL
+          #   PUBLIC_SUPABASE_ANON_KEY -> your Supabase anon/public key
+          # SvelteKit's $env/static/public reads PUBLIC_* from process.env at build time
+          # VITE_* prefix makes them also available via import.meta.env if needed
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
+          VITE_PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          VITE_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,6 +12,9 @@ const config = {
 			precompress: false,
 			strict: true,
 		}),
+		paths: {
+			base: process.env.KIT_BASE_PATH || '',
+		},
 	},
 };
 


### PR DESCRIPTION
## Summary

- Renamed repository from Chess to Pawnly on GitHub
- Added GitHub Pages deployment workflow (`.github/workflows/deploy-pages.yml`)
- Updated `svelte.config.js` to support base path for GH Pages

## Changes

### GitHub Pages Workflow (`deploy-pages.yml`)
- Triggers on push to `main` and `workflow_dispatch`
- Uses `ubuntu-latest` (GitHub-hosted runners required for GH Pages)
- Installs pnpm (latest) and Node 22
- Runs lint, typecheck, and test before building
- Builds with `KIT_BASE_PATH=/Pawnly` for correct asset paths on GH Pages
- Passes Supabase secrets as env vars at build time
- Uses `actions/deploy-pages@v4`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`
- Sets permissions: `pages: write`, `id-token: write`

### svelte.config.js
- Added `kit.paths.base` reading from `KIT_BASE_PATH` env var
- Defaults to empty string for local dev, set to `/Pawnly` in CI for GH Pages

## Setup Required

After merging, configure these **GitHub repository secrets**:
- `PUBLIC_SUPABASE_URL` — your Supabase project URL
- `PUBLIC_SUPABASE_ANON_KEY` — your Supabase anon/public key

Also enable GitHub Pages in repo Settings > Pages:
- Source: **GitHub Actions** (not `gh-pages` branch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for deploying to GitHub Pages on pushes to the main branch and manual triggers
  * Updated configuration to support environment-based base path settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->