### PR TITLE
fix: replace broken pnpm approve-builds config with onlyBuiltDependencies

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,9 +32,6 @@ jobs:
           node-version: '22'
           cache: pnpm
 
-      - name: Configure pnpm to auto-approve build scripts
-        run: pnpm config set approve-builds-on-install true
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
 		"@supabase/supabase-js": "^2.105.3",
 		"chess.js": "^1.4.0",
 		"stockfish": "^18.0.7"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["esbuild", "stockfish", "supabase"]
 	}
 }


### PR DESCRIPTION
## Problem

The deploy workflow fails because `pnpm config set approve-builds-on-install true` does not work for global config in pnpm v10. This causes `pnpm install` to hang or error when packages with build scripts (esbuild, stockfish, supabase) need approval.

## Fix

- Add `pnpm.onlyBuiltDependencies` to root `package.json` listing the packages allowed to run build scripts: esbuild, stockfish, supabase
- Remove the broken `pnpm config set approve-builds-on-install true` step from `.github/workflows/deploy-pages.yml`

This is the recommended approach for pnpm v10 — declaring approved build packages explicitly in package.json rather than relying on a global config setting that no longer functions.

## Changes

- `package.json` — added `"pnpm": { "onlyBuiltDependencies": ["esbuild", "stockfish", "supabase"] }`
- `.github/workflows/deploy-pages.yml` — removed the `Configure pnpm to auto-approve build scripts` step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment pipeline configuration to optimize dependency handling.
  * Refined package manager settings for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->