### PR TITLE
fix(ci): add pnpm approve-builds step and pin pnpm v10

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,13 +24,16 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: pnpm
+
+      - name: Approve build scripts
+        run: pnpm approve-builds esbuild stockfish supabase
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Fixes ERR_PNPM_IGNORED_BUILDS by adding `pnpm approve-builds esbuild stockfish supabase` step before install. Also pins pnpm to v10 to match lockfile format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Pages deployment workflow with enhanced dependency management, explicit build caching, and automated build script approval to improve deployment reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->