### PR TITLE
feat(ai): env-driven AI provider switching with Ollama sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# ── AI Provider ──────────────────────────────────────────────────
+# ollama     → localhost Ollama (dev)
+# mini       → small models via localhost Ollama (phi3, tinyllama)
+# openrouter → OpenRouter cloud API (requires API key)
+# groq       → Groq cloud API (requires API key)
+PUBLIC_AI_PROVIDER=ollama
+
+# ── Cloud API Keys (for openrouter / groq) ──
+# Never expose these in client bundles. Use a Supabase Edge Function
+# or backend proxy to relay requests with the secret key.
+# VITE_OPENROUTER_API_KEY=
+# VITE_GROQ_API_KEY=
+
+# ── Supabase ─────────────────────────────────────────────────────
+PUBLIC_SUPABASE_URL=
+PUBLIC_SUPABASE_ANON_KEY=

--- a/.env.example
+++ b/.env.example
@@ -3,13 +3,23 @@
 # mini       → small models via localhost Ollama (phi3, tinyllama)
 # openrouter → OpenRouter cloud API (requires API key)
 # groq       → Groq cloud API (requires API key)
-PUBLIC_AI_PROVIDER=ollama
+AI_PROVIDER=ollama
 
-# ── Cloud API Keys (for openrouter / groq) ──
-# Never expose these in client bundles. Use a Supabase Edge Function
-# or backend proxy to relay requests with the secret key.
-# VITE_OPENROUTER_API_KEY=
-# VITE_GROQ_API_KEY=
+# ── Local AI Base URL ───────────────────────────────────────────
+# Used by ollama/mini providers. Defaults to http://localhost:11434
+# In Docker, set to http://ollama:11434 (service name)
+# LOCAL_AI_BASE_URL=http://localhost:11434
+
+# ── Cloud API Keys (for openrouter / groq) ──────────────────────
+# Server-only env vars. Never exposed to client bundles.
+# OPENROUTER_API_KEY=
+# GROQ_API_KEY=
+
+# ── Model overrides (optional) ──────────────────────────────────
+# OLLAMA_MODEL=mistral
+# MINI_MODEL=phi3:mini
+# OPENROUTER_MODEL=openai/gpt-4o-mini
+# GROQ_MODEL=llama3-70b-8192
 
 # ── Supabase ─────────────────────────────────────────────────────
 PUBLIC_SUPABASE_URL=

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -12,6 +12,13 @@ concurrency:
 
 jobs:
   pr-agent:
+    if: >
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: self-hosted
     permissions:
       contents: read
@@ -45,13 +52,18 @@ jobs:
           PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             pr-agent --pr_url="$PR_URL" review
-          elif echo "$COMMENT_BODY" | grep -q "^/review"; then
+          elif echo "$COMMENT_BODY" | grep -qE '^/review([[:space:]]|$)'; then
             pr-agent --pr_url="$PR_URL" review
-          elif echo "$COMMENT_BODY" | grep -q "^/describe"; then
+          elif echo "$COMMENT_BODY" | grep -qE '^/describe([[:space:]]|$)'; then
             pr-agent --pr_url="$PR_URL" describe
-          elif echo "$COMMENT_BODY" | grep -q "^/improve"; then
+          elif echo "$COMMENT_BODY" | grep -qE '^/improve([[:space:]]|$)'; then
             pr-agent --pr_url="$PR_URL" improve
-          elif echo "$COMMENT_BODY" | grep -q "^/ask"; then
-            QUESTION="${COMMENT_BODY#/ask }"
+          elif echo "$COMMENT_BODY" | grep -qE '^/ask([[:space:]].+)?$'; then
+            QUESTION="${COMMENT_BODY#/ask}"
+            QUESTION="${QUESTION# }"
+            if [ -z "$QUESTION" ]; then
+              echo "Usage: /ask <question>"
+              exit 1
+            fi
             pr-agent --pr_url="$PR_URL" ask "$QUESTION"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 # Environment
 .env
 .env.*
+!.env.example
 .env.local
 .env.*.local
 
@@ -36,3 +37,4 @@ coverage/
 
 # Repomix
 repomix-output.txt
+.worktrees/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     image: nginx:alpine
     ports:
       - '${PORT:-8080}:80'
+    environment:
+      - LOCAL_AI_BASE_URL=http://ollama:11434
     volumes:
       - ./build:/usr/share/nginx/html:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
@@ -17,7 +19,7 @@ services:
   ollama:
     image: ollama/ollama:latest
     ports:
-      - '11434:11434'
+      - '127.0.0.1:11434:11434'
     volumes:
       - ollama-data:/root/.ollama
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+# Production deployment with Ollama sidecar for AI features.
+# The "mini" provider runs small models (phi3, tinyllama) on CPU
+# via the Ollama service. The SvelteKit static build is served by nginx.
+
+services:
+  app:
+    image: nginx:alpine
+    ports:
+      - '${PORT:-8080}:80'
+    volumes:
+      - ./build:/usr/share/nginx/html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    restart: unless-stopped
+    depends_on:
+      - ollama
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - '11434:11434'
+    volumes:
+      - ollama-data:/root/.ollama
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        ollama serve &
+        sleep 3
+        ollama pull phi3:mini || true
+        ollama pull nomic-embed-text || true
+        wait
+
+volumes:
+  ollama-data:

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,35 +1,63 @@
-import { env } from '$env/dynamic/public';
+import { env } from '$env/dynamic/private';
 
 export type AIProvider = 'ollama' | 'openrouter' | 'groq' | 'mini';
 
-const OLLAMA_BASE = 'http://localhost:11434';
+const VALID_PROVIDERS: AIProvider[] = ['ollama', 'mini', 'openrouter', 'groq'];
+const AI_REQUEST_TIMEOUT_MS = 30000;
 
 function getProvider(): AIProvider {
-	return (env.PUBLIC_AI_PROVIDER as AIProvider | undefined) ?? 'ollama';
+	const provider = (env.AI_PROVIDER || 'ollama') as AIProvider;
+	if (!VALID_PROVIDERS.includes(provider)) {
+		console.warn(`Invalid AI_PROVIDER "${env.AI_PROVIDER}", falling back to "ollama"`);
+		return 'ollama';
+	}
+	return provider;
+}
+
+function getOllamaBase(): string {
+	return env.LOCAL_AI_BASE_URL || 'http://localhost:11434';
 }
 
 function getBaseUrl(provider: AIProvider): string {
 	switch (provider) {
 		case 'mini':
 		case 'ollama':
-			return OLLAMA_BASE;
+			return getOllamaBase();
 		case 'openrouter':
 			return 'https://openrouter.ai/api/v1';
 		case 'groq':
 			return 'https://api.groq.com/openai/v1';
+		default:
+			return getOllamaBase();
 	}
 }
 
 function getDefaultModel(provider: AIProvider): string {
 	switch (provider) {
 		case 'mini':
-			return 'phi3:mini';
+			return env.MINI_MODEL || 'phi3:mini';
 		case 'ollama':
-			return 'mistral';
+			return env.OLLAMA_MODEL || 'mistral';
 		case 'openrouter':
-			return 'openai/gpt-4o-mini';
+			return env.OPENROUTER_MODEL || 'openai/gpt-4o-mini';
 		case 'groq':
-			return 'llama3-70b-8192';
+			return env.GROQ_MODEL || 'llama3-70b-8192';
+		default:
+			return env.OLLAMA_MODEL || 'mistral';
+	}
+}
+
+function getAPIKey(provider: AIProvider): string | null {
+	switch (provider) {
+		case 'mini':
+		case 'ollama':
+			return null;
+		case 'openrouter':
+			return env.OPENROUTER_API_KEY || null;
+		case 'groq':
+			return env.GROQ_API_KEY || null;
+		default:
+			return null;
 	}
 }
 
@@ -58,8 +86,42 @@ interface ChatOptions {
 	maxTokens?: number;
 }
 
+interface ChatCompletionResponse {
+	choices?: Array<{ message?: { content?: string } }>;
+}
+
+interface OllamaGenerateResponse {
+	response?: string;
+}
+
+interface OllamaChatResponse {
+	message?: { content?: string };
+}
+
+interface OllamaEmbedResponse {
+	embedding?: number[];
+}
+
+interface OpenAIEmbedResponse {
+	data?: Array<{ embedding: number[] }>;
+}
+
+async function parseJsonOrThrow(res: Response): Promise<Record<string, unknown>> {
+	if (!res.ok) {
+		const body = await res.text().catch(() => '');
+		throw new Error(`AI request failed: ${res.status} ${res.statusText}. ${body}`);
+	}
+	return res.json().catch(() => ({}));
+}
+
+function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), AI_REQUEST_TIMEOUT_MS);
+	return fetch(url, { ...init, signal: controller.signal }).finally(() => clearTimeout(timeoutId));
+}
+
 async function ollamaRequest(path: string, body: Record<string, unknown>): Promise<Response> {
-	return fetch(`${OLLAMA_BASE}/api/${path}`, {
+	return fetchWithTimeout(`${getOllamaBase()}/api/${path}`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(body),
@@ -75,7 +137,7 @@ async function openAICompatible(path: string, body: Record<string, unknown>): Pr
 		throw new Error(`No API key configured for provider "${provider}". Set the key in your edge function or proxy.`);
 	}
 
-	return fetch(`${baseUrl}/${path}`, {
+	return fetchWithTimeout(`${baseUrl}/${path}`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
@@ -85,25 +147,6 @@ async function openAICompatible(path: string, body: Record<string, unknown>): Pr
 	});
 }
 
-function getAPIKey(provider: AIProvider): string | null {
-	switch (provider) {
-		case 'mini':
-		case 'ollama':
-			return null;
-		case 'openrouter':
-			return import.meta.env.VITE_OPENROUTER_API_KEY || null;
-		case 'groq':
-			return import.meta.env.VITE_GROQ_API_KEY || null;
-	}
-}
-
-/**
- * Generate a text completion.
- *
- * For cloud providers (openrouter, groq), API keys must be provided
- * through a Supabase Edge Function or backend proxy — never expose
- * secret keys in client-side bundles.
- */
 export async function generate(opts: GenerateOptions): Promise<string> {
 	const provider = getProvider();
 	const model = opts.model ?? getDefaultModel(provider);
@@ -119,8 +162,12 @@ export async function generate(opts: GenerateOptions): Promise<string> {
 				num_predict: opts.maxTokens,
 			},
 		});
-		const json = await res.json();
-		return json.response as string;
+		const json = (await parseJsonOrThrow(res)) as OllamaGenerateResponse;
+		const content = json.response;
+		if (typeof content !== 'string') {
+			throw new Error('Invalid AI response: missing response content');
+		}
+		return content;
 	}
 
 	const res = await openAICompatible('chat/completions', {
@@ -132,39 +179,35 @@ export async function generate(opts: GenerateOptions): Promise<string> {
 		temperature: opts.temperature ?? 0.7,
 		max_tokens: opts.maxTokens,
 	});
-	const json = await res.json();
-	return json.choices?.[0]?.message?.content ?? '';
+	const json = (await parseJsonOrThrow(res)) as ChatCompletionResponse;
+	const content = json.choices?.[0]?.message?.content;
+	if (typeof content !== 'string') {
+		throw new Error('Invalid AI response: missing message content');
+	}
+	return content;
 }
 
-/**
- * Generate embeddings for semantic search or recommendations.
- *
- * Uses Ollama locally; for cloud providers, the `/embeddings` OpenAI-compatible
- * endpoint is used (supported by both OpenRouter and Groq).
- */
 export async function embed(opts: EmbedOptions): Promise<number[][]> {
 	const provider = getProvider();
-	const model = opts.model ?? (provider === 'mini' ? 'nomic-embed-text' : getDefaultModel(provider));
+	const model =
+		opts.model ?? (provider === 'mini' || provider === 'ollama' ? 'nomic-embed-text' : getDefaultModel(provider));
 	const inputs = Array.isArray(opts.input) ? opts.input : [opts.input];
 
 	if (provider === 'ollama' || provider === 'mini') {
-		const results: number[][] = [];
-		for (const input of inputs) {
-			const res = await ollamaRequest('embeddings', { model, prompt: input });
-			const json = await res.json();
-			results.push(json.embedding as number[]);
-		}
-		return results;
+		return Promise.all(
+			inputs.map(async (input) => {
+				const res = await ollamaRequest('embeddings', { model, prompt: input });
+				const json = (await parseJsonOrThrow(res)) as OllamaEmbedResponse;
+				return json.embedding as number[];
+			}),
+		);
 	}
 
 	const res = await openAICompatible('embeddings', { model, input: inputs });
-	const json = await res.json();
-	return (json.data as Array<{ embedding: number[] }>).map((d) => d.embedding);
+	const json = (await parseJsonOrThrow(res)) as OpenAIEmbedResponse;
+	return (json.data ?? []).map((d) => d.embedding);
 }
 
-/**
- * Multi-turn chat completion for AI coach conversations.
- */
 export async function chat(opts: ChatOptions): Promise<string> {
 	const provider = getProvider();
 	const model = opts.model ?? getDefaultModel(provider);
@@ -179,8 +222,12 @@ export async function chat(opts: ChatOptions): Promise<string> {
 				num_predict: opts.maxTokens,
 			},
 		});
-		const json = await res.json();
-		return json.message?.content as string;
+		const json = (await parseJsonOrThrow(res)) as OllamaChatResponse;
+		const content = json.message?.content;
+		if (typeof content !== 'string') {
+			throw new Error('Invalid AI response: missing message content');
+		}
+		return content;
 	}
 
 	const res = await openAICompatible('chat/completions', {
@@ -189,6 +236,10 @@ export async function chat(opts: ChatOptions): Promise<string> {
 		temperature: opts.temperature ?? 0.7,
 		max_tokens: opts.maxTokens,
 	});
-	const json = await res.json();
-	return json.choices?.[0]?.message?.content ?? '';
+	const json = (await parseJsonOrThrow(res)) as ChatCompletionResponse;
+	const content = json.choices?.[0]?.message?.content;
+	if (typeof content !== 'string') {
+		throw new Error('Invalid AI response: missing message content');
+	}
+	return content;
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,194 @@
+import { env } from '$env/dynamic/public';
+
+export type AIProvider = 'ollama' | 'openrouter' | 'groq' | 'mini';
+
+const OLLAMA_BASE = 'http://localhost:11434';
+
+function getProvider(): AIProvider {
+	return (env.PUBLIC_AI_PROVIDER as AIProvider | undefined) ?? 'ollama';
+}
+
+function getBaseUrl(provider: AIProvider): string {
+	switch (provider) {
+		case 'mini':
+		case 'ollama':
+			return OLLAMA_BASE;
+		case 'openrouter':
+			return 'https://openrouter.ai/api/v1';
+		case 'groq':
+			return 'https://api.groq.com/openai/v1';
+	}
+}
+
+function getDefaultModel(provider: AIProvider): string {
+	switch (provider) {
+		case 'mini':
+			return 'phi3:mini';
+		case 'ollama':
+			return 'mistral';
+		case 'openrouter':
+			return 'openai/gpt-4o-mini';
+		case 'groq':
+			return 'llama3-70b-8192';
+	}
+}
+
+interface GenerateOptions {
+	model?: string;
+	prompt: string;
+	system?: string;
+	temperature?: number;
+	maxTokens?: number;
+}
+
+interface EmbedOptions {
+	model?: string;
+	input: string | string[];
+}
+
+interface ChatMessage {
+	role: 'system' | 'user' | 'assistant';
+	content: string;
+}
+
+interface ChatOptions {
+	model?: string;
+	messages: ChatMessage[];
+	temperature?: number;
+	maxTokens?: number;
+}
+
+async function ollamaRequest(path: string, body: Record<string, unknown>): Promise<Response> {
+	return fetch(`${OLLAMA_BASE}/api/${path}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+}
+
+async function openAICompatible(path: string, body: Record<string, unknown>): Promise<Response> {
+	const provider = getProvider();
+	const baseUrl = getBaseUrl(provider);
+	const apiKey = getAPIKey(provider);
+
+	if (!apiKey) {
+		throw new Error(`No API key configured for provider "${provider}". Set the key in your edge function or proxy.`);
+	}
+
+	return fetch(`${baseUrl}/${path}`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiKey}`,
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function getAPIKey(provider: AIProvider): string | null {
+	switch (provider) {
+		case 'mini':
+		case 'ollama':
+			return null;
+		case 'openrouter':
+			return import.meta.env.VITE_OPENROUTER_API_KEY || null;
+		case 'groq':
+			return import.meta.env.VITE_GROQ_API_KEY || null;
+	}
+}
+
+/**
+ * Generate a text completion.
+ *
+ * For cloud providers (openrouter, groq), API keys must be provided
+ * through a Supabase Edge Function or backend proxy — never expose
+ * secret keys in client-side bundles.
+ */
+export async function generate(opts: GenerateOptions): Promise<string> {
+	const provider = getProvider();
+	const model = opts.model ?? getDefaultModel(provider);
+
+	if (provider === 'ollama' || provider === 'mini') {
+		const res = await ollamaRequest('generate', {
+			model,
+			prompt: opts.prompt,
+			system: opts.system,
+			stream: false,
+			options: {
+				temperature: opts.temperature ?? 0.7,
+				num_predict: opts.maxTokens,
+			},
+		});
+		const json = await res.json();
+		return json.response as string;
+	}
+
+	const res = await openAICompatible('chat/completions', {
+		model,
+		messages: [
+			...(opts.system ? [{ role: 'system' as const, content: opts.system }] : []),
+			{ role: 'user' as const, content: opts.prompt },
+		],
+		temperature: opts.temperature ?? 0.7,
+		max_tokens: opts.maxTokens,
+	});
+	const json = await res.json();
+	return json.choices?.[0]?.message?.content ?? '';
+}
+
+/**
+ * Generate embeddings for semantic search or recommendations.
+ *
+ * Uses Ollama locally; for cloud providers, the `/embeddings` OpenAI-compatible
+ * endpoint is used (supported by both OpenRouter and Groq).
+ */
+export async function embed(opts: EmbedOptions): Promise<number[][]> {
+	const provider = getProvider();
+	const model = opts.model ?? (provider === 'mini' ? 'nomic-embed-text' : getDefaultModel(provider));
+	const inputs = Array.isArray(opts.input) ? opts.input : [opts.input];
+
+	if (provider === 'ollama' || provider === 'mini') {
+		const results: number[][] = [];
+		for (const input of inputs) {
+			const res = await ollamaRequest('embeddings', { model, prompt: input });
+			const json = await res.json();
+			results.push(json.embedding as number[]);
+		}
+		return results;
+	}
+
+	const res = await openAICompatible('embeddings', { model, input: inputs });
+	const json = await res.json();
+	return (json.data as Array<{ embedding: number[] }>).map((d) => d.embedding);
+}
+
+/**
+ * Multi-turn chat completion for AI coach conversations.
+ */
+export async function chat(opts: ChatOptions): Promise<string> {
+	const provider = getProvider();
+	const model = opts.model ?? getDefaultModel(provider);
+
+	if (provider === 'ollama' || provider === 'mini') {
+		const res = await ollamaRequest('chat', {
+			model,
+			messages: opts.messages,
+			stream: false,
+			options: {
+				temperature: opts.temperature ?? 0.7,
+				num_predict: opts.maxTokens,
+			},
+		});
+		const json = await res.json();
+		return json.message?.content as string;
+	}
+
+	const res = await openAICompatible('chat/completions', {
+		model,
+		messages: opts.messages,
+		temperature: opts.temperature ?? 0.7,
+		max_tokens: opts.maxTokens,
+	});
+	const json = await res.json();
+	return json.choices?.[0]?.message?.content ?? '';
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/ai.ts` with env-driven `AI_PROVIDER` switching (ollama/mini/openrouter/groq)
- Add `docker-compose.yml` with app + Ollama sidecar for local and production use
- Add `.env.example` with AI_PROVIDER and model configuration vars
- Add `.github/workflows/pr-agent.yml` for self-hosted PR-Agent via LM Studio

## AI Provider Strategy
Single `AI_PROVIDER` env var switches backend. Code never changes — only `.env` does:
- `AI_PROVIDER=mini` — CPU-friendly models (phi3:mini/gemma2:2b) via Ollama sidecar on Droplet. For v0 testing.
- `AI_PROVIDER=openrouter` — OpenRouter API (cheap multi-model access)
- `AI_PROVIDER=groq` — Groq API (fast cheap inference)
- `AI_PROVIDER=ollama` — localhost dev only ($0 cost)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-provider AI support (local and cloud) with text generation, embeddings, and chat
  * Docker Compose setup for easy local deployment including a local AI sidecar

* **Documentation**
  * Example environment file populated with AI provider and public Supabase placeholders

* **Chores**
  * GitHub workflow tightened for PR comment handling; .gitignore and config updates for local dev
<!-- end of auto-generated comment: release notes by coderabbit.ai -->