### PR TITLE
fix: shared Ollama + pnpm allowBuilds for Coolify deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts=false
 
 COPY . .
 RUN pnpm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,33 +7,13 @@ services:
       - '${PORT:-8080}:80'
     environment:
       - AI_PROVIDER=${AI_PROVIDER:-mini}
-      - LOCAL_AI_BASE_URL=http://ollama:11434
+      - LOCAL_AI_BASE_URL=http://ollama-shared:11434
       - MINI_MODEL=${MINI_MODEL:-phi3:mini}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma2:2b}
     restart: unless-stopped
-    depends_on:
-      - ollama
+    networks:
+      - coolify
 
-  ollama:
-    image: ollama/ollama:latest
-    ports:
-      - '127.0.0.1:11434:11434'
-    volumes:
-      - ollama-data:/root/.ollama
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 4G
-    entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        ollama serve &
-        sleep 3
-        ollama pull phi3:mini || true
-        ollama pull nomic-embed-text || true
-        wait
-
-volumes:
-  ollama-data:
+networks:
+  coolify:
+    external: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: set this to true or false
+  stockfish: set this to true or false
+  supabase: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
+packages: []
+
 allowBuilds:
-  esbuild: set this to true or false
-  stockfish: set this to true or false
-  supabase: set this to true or false
+  esbuild: true
+  stockfish: true
+  supabase: true


### PR DESCRIPTION
## Summary
- Replace per-app Ollama sidecar with shared `ollama-shared` container on Docker `coolify` network (eliminates port 11434 conflict)
- Add `pnpm-workspace.yaml` with `allowBuilds` for esbuild/stockfish/supabase
- Dockerfile uses `--ignore-scripts=false` for native binary downloads
- Fix allowBuilds values to proper booleans

Supersedes #117 (conflicting branch). Vidiom/Songster/ObstetraScroll already have these changes on main/master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to properly execute dependency lifecycle scripts during installation.
  * Reconfigured service networking to connect to a shared external infrastructure component.
  * Added workspace and build tool configuration for improved development and deployment support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->