### PR TITLE
fix: copy pnpm-workspace.yaml before install for allowBuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --ignore-scripts=false
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm run build


### PR DESCRIPTION
Fix `ERR_PNPM_IGNORED_BUILDS` by copying `pnpm-workspace.yaml` (with `allowBuilds`) before `pnpm install`. Removes `--ignore-scripts=false` (unnecessary with `allowBuilds`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve dependency management and reproducibility. The build process now uses a workspace configuration and frozen dependency lockfile to ensure consistent installations across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->