### PR TITLE
fix: add core-js + protobufjs to pnpm allowBuilds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages: []
 
 allowBuilds:
+  core-js: true
   esbuild: true
+  protobufjs: true
   stockfish: true
   supabase: true


### PR DESCRIPTION
## Summary
- Add `core-js: true` and `protobufjs: true` to `allowBuilds` in `pnpm-workspace.yaml`
- Fixes `pnpm install --frozen-lockfile` failure during Coolify Docker build (pnpm v10+ blocks postinstall scripts not in allowBuilds)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to enable core library builds while maintaining compatibility with existing build processes, improving overall project consistency and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->