### PR TITLE
fix: add Traefik labels and Supabase env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
       - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma2:2b}
       - PUBLIC_POSTHOG_HOST=${PUBLIC_POSTHOG_HOST:-https://us.posthog.com}
       - PUBLIC_POSTHOG_PROJECT_TOKEN=${PUBLIC_POSTHOG_PROJECT_TOKEN:-}
+      - PUBLIC_SUPABASE_URL=${PUBLIC_SUPABASE_URL:-}
+      - PUBLIC_SUPABASE_ANON_KEY=${PUBLIC_SUPABASE_ANON_KEY:-}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.pawnly.rule=Host(`pawnly.159.223.26.67.sslip.io`)
+      - traefik.http.routers.pawnly.entrypoints=http
+      - traefik.http.services.pawnly.loadbalancer.server.port=80
     restart: unless-stopped
     networks:
       - coolify


### PR DESCRIPTION
Add Traefik routing labels for sslip.io domain and pass PUBLIC_SUPABASE_URL/PUBLIC_SUPABASE_ANON_KEY via compose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Supabase configuration variables to service environment
  * Configured service routing and load balancing settings

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/Pawnly/pull/124)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->