### PR TITLE
fix: add ORIGIN env var for CSRF protection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,11 @@ services:
       - LOCAL_AI_BASE_URL=http://ollama-shared:11434
       - MINI_MODEL=${MINI_MODEL:-phi3:mini}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-gemma2:2b}
-      - PUBLIC_POSTHOG_HOST=${PUBLIC_POSTHOG_HOST:-https://us.posthog.com}
+      - PUBLIC_POSTHOG_HOST=${PUBLIC_POSTHOG_HOST:-https://eu.i.posthog.com}
       - PUBLIC_POSTHOG_PROJECT_TOKEN=${PUBLIC_POSTHOG_PROJECT_TOKEN:-}
       - PUBLIC_SUPABASE_URL=${PUBLIC_SUPABASE_URL:-}
       - PUBLIC_SUPABASE_ANON_KEY=${PUBLIC_SUPABASE_ANON_KEY:-}
+      - ORIGIN=${ORIGIN:-http://localhost:8081}
     labels:
       - traefik.enable=true
       - traefik.http.routers.pawnly.rule=Host(`pawnly.159.223.26.67.sslip.io`)


### PR DESCRIPTION
## Summary
- Add ORIGIN env var to docker-compose.yml
- Required for SvelteKit CSRF form submission validation
- Without it, SvelteKit defaults to localhost which doesn't match sslip.io origin
- Also fix PostHog host default to EU region

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics service endpoint configuration to route through the EU region instead of the US region.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/Pawnly/pull/129)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->