### PR TITLE
feat: add TLS/HTTPS via Let's Encrypt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       - traefik.enable=true
       - traefik.http.routers.pawnly.rule=Host(`pawnly.159.223.26.67.sslip.io`)
       - traefik.http.routers.pawnly.entrypoints=http
+      - traefik.http.routers.pawnly-https.rule=Host(`pawnly.159.223.26.67.sslip.io`)
+      - traefik.http.routers.pawnly-https.entrypoints=https
+      - traefik.http.routers.pawnly-https.tls=true
+      - traefik.http.routers.pawnly-https.tls.certresolver=letsencrypt
       - traefik.http.services.pawnly.loadbalancer.server.port=80
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary
- Add HTTPS router to Traefik labels in docker-compose.yml
- Uses existing Let's Encrypt certresolver configured on coolify-proxy
- TLS termination at Traefik level, apps continue serving HTTP internally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended infrastructure configuration to support HTTPS routing with automatic TLS certificate management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/Pawnly/pull/130)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->